### PR TITLE
Allow custom instance of DefaultValuesTZMapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ $RECYCLE.BIN/
 
 # VS files
 .vs/
+
+# Rider files
+.idea/

--- a/TimeZoneMapper.Tests/TimezoneMapper.Tests.csproj
+++ b/TimeZoneMapper.Tests/TimezoneMapper.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/TimeZoneMapper.Tests/TimezoneMapper.Tests.csproj
+++ b/TimeZoneMapper.Tests/TimezoneMapper.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net462</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/TimeZoneMapper/TZMappers/DefaultValuesTZMapper.cs
+++ b/TimeZoneMapper/TZMappers/DefaultValuesTZMapper.cs
@@ -5,7 +5,18 @@
     /// </summary>
     public sealed class DefaultValuesTZMapper : BaseTZMapper, ITZMapper
     {
-        internal DefaultValuesTZMapper()
-            : base(Properties.Resources.windowsZones) { }
+        /// <summary>
+        /// Provides TimeZoneID mapping based on a built-in (&quot;static&quot;) resource.
+        /// </summary>
+        /// <param name="throwOnDuplicateKey">
+        /// When true, an exception will be thrown when the XML data contains duplicate timezones. When false, 
+        /// duplicates are ignored and only the first entry in the XML data will be used.
+        /// </param>
+        /// <param name="throwOnNonExisting">
+        /// When true, an exception will be thrown when the XML data contains non-existing timezone ID's. When false,
+        /// non-existing timezone ID's are ignored.
+        /// </param>
+        public DefaultValuesTZMapper(bool throwOnDuplicateKey = true, bool throwOnNonExisting = true)
+            : base(Properties.Resources.windowsZones, throwOnDuplicateKey, throwOnNonExisting) { }
     }
 }

--- a/TimeZoneMapper/TimeZoneMap.cs
+++ b/TimeZoneMapper/TimeZoneMap.cs
@@ -26,6 +26,7 @@
         ///         properties.
         ///     </para>
         /// </remarks>
+        /// <exception cref="TimeZoneNotFoundException">when a mapped zone cannot be found in the current OS. It may occur on outdated Windows versions. </exception>
         public static ITZMapper DefaultValuesTZMapper { get { return _defaultvaluesmapper.Value; } }
 
         /// <summary>


### PR DESCRIPTION
These changes allow developers to create a custom instance of the `DefaultValuesTZMapper`. Passing false in arguments will prevent exception from occurring on outdated windows versions (see #15). 

Proposed usage: 

```
private static readonly Lazy<DefaultValuesTZMapper> mapper;

static TZDB()
{
    mapper = new Lazy<DefaultValuesTZMapper>(() => new DefaultValuesTZMapper(true, false));
}
```

Workaround: 

```
private static readonly Lazy<ITZMapper> mapper;

static TZDB()
{
    mapper = new Lazy<ITZMapper>(() =>
    {
        // TODO: uncomment this when https://github.com/RobThree/TimeZoneMapper/pull/16 is merged and nuget updated
        ////return new DefaultValuesTZMapper(true, false);

        // NOTE: this code prevents a crash from `TimeZoneMap.DefaultValuesTZMapper` until PR https://github.com/RobThree/TimeZoneMapper/pull/16 is merged
        var assembly = typeof(CustomValuesTZMapper).Assembly;
        var mappingStream = assembly.GetManifestResourceStream(assembly.GetName().Name + ".ResourceFiles.windowsZones.xml");
        using (var reader = new StreamReader(mappingStream, Encoding.UTF8))
        {
            var mappingContents = reader.ReadToEnd();
            var item = new CustomValuesTZMapper(mappingContents, throwOnNonExisting: false);
            return item;
        }
    });
}
```